### PR TITLE
Use Dict declaration that is compatible with 0.3 - 0.5

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -25,4 +25,4 @@ provides(BuildProcess,
         end
     end), blossom5)
 
-@BinDeps.install Dict(:blossom5  => :_jl_blossom5)
+@BinDeps.install Dict([(:blossom5, :_jl_blossom5)])


### PR DESCRIPTION
The kv list declaration of dicts should be compatible with version of julia from 0.3 to 0.5
I don't have a copy of 0.3 to check (bu i did check the source code)

This should address https://github.com/JuliaLang/METADATA.jl/pull/5619#issuecomment-233104913
(I'm not certain, since I don't have 0.3 to test)
It might be better to just update REQUIRE and not support 0.3