### PR TITLE
Remove reference to Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ or similar.
 A common thing that goes wrong is not having current enough version of C++ and
 its stdlibs. Currently the minimum requirements are a compiler supporting the
 C++11 standard (e.g. gcc-4.6 on ubuntu 14.04 should be recent enough).
+You can check your current compiler by running `c++ --version` from the shell.


### PR DESCRIPTION
Getting GCC 4.6 on to Ubuntu 14.04 is non-trivial, as it is not in the standard repositories.
Referring to Ubuntu 14.04 without further instructions, gives the incorrect impression that if you have Ubuntu 14.04 you are going to have an Ok time. 

Better to just refer to GCC 4.6, and let the user workout for themselves how to install it.
And a hint on how to check it is right.