### PR TITLE
matching with floats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: julia
+
 notifications:
   email: false
+
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
+
 matrix:
   allow_failures:
     - julia: nightly

--- a/README.md
+++ b/README.md
@@ -27,3 +27,32 @@ A common thing that goes wrong is not having current enough version of C++ and
 its stdlibs. Currently the minimum requirements are a compiler supporting the
 C++11 standard (e.g. gcc-4.6 on ubuntu 12.04, or newer, should be recent
 enough).
+
+## Usage
+The main exported type is `Matching`. Here is its docstring:
+
+```julia
+"""
+    type Matching{T<:Union{Int32, Float64}}
+        ptr::Ptr{Void}
+    end
+
+A type containing a pointer to a BlossomV struct for perfect matching.
+`T` is the type of the edge weights.
+
+The following constructors are available:
+
+    Matching(node_num)
+    Matching(node_num, edge_num_max)
+    Matching(T, node_num)
+    Matching(T, node_num, edge_num_max)
+
+If `T` is not given it will default to `Int32`.
+
+After adding edges and weights with `add_edge(match, i, j, weight)`
+use `solve(match)` to find an optimal matching and `get_match(match, i)`
+to retrieve it.
+"""
+```
+
+See `test/runtests.jl` for usage examples.

--- a/README.md
+++ b/README.md
@@ -27,32 +27,3 @@ A common thing that goes wrong is not having current enough version of C++ and
 its stdlibs. Currently the minimum requirements are a compiler supporting the
 C++11 standard (e.g. gcc-4.6 on ubuntu 12.04, or newer, should be recent
 enough).
-
-## Usage
-The main exported type is `Matching`. Here is its docstring:
-
-```julia
-"""
-    type Matching{T<:Union{Int32, Float64}}
-        ptr::Ptr{Void}
-    end
-
-A type containing a pointer to a BlossomV struct for perfect matching.
-`T` is the type of the edge weights.
-
-The following constructors are available:
-
-    Matching(node_num)
-    Matching(node_num, edge_num_max)
-    Matching(T, node_num)
-    Matching(T, node_num, edge_num_max)
-
-If `T` is not given it will default to `Int32`.
-
-After adding edges and weights with `add_edge(match, i, j, weight)`
-use `solve(match)` to find an optimal matching and `get_match(match, i)`
-to retrieve it.
-"""
-```
-
-See `test/runtests.jl` for usage examples.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 BinDeps

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,29 +16,51 @@ function validate(name, handle)
     return version < bin_version
 end
 
-blossom5 = library_dependency("blossom5", validate=validate)
+blossom5int32 = library_dependency("blossom5int32", validate=validate)
+blossom5float64 = library_dependency("blossom5float64")
 
-provides(Sources, URI("http://pub.ist.ac.at/~vnk/software/blossom5-v2.05.src.tar.gz"), blossom5, SHA="6bb2fabaa4a5eb957385c81f2cdad139454afebbdb19d6deea61ced5f7c06489")
+provides(Sources, URI("http://pub.ist.ac.at/~vnk/software/blossom5-v2.05.src.tar.gz"), blossom5int32, SHA="6bb2fabaa4a5eb957385c81f2cdad139454afebbdb19d6deea61ced5f7c06489")
 
-prefix = usrdir(blossom5)
-blossom5srcdir = joinpath(srcdir(blossom5), "blossom5-v2.05.src")
+prefix = usrdir(blossom5int32)
+blossom5srcdir = joinpath(srcdir(blossom5int32), "blossom5-v2.05.src")
 
 provides(BuildProcess,
     (@build_steps begin
-        `rm -rf $prefix`
+        # `rm -rf $prefix`
         `rm -rf $blossom5srcdir`
-        GetSources(blossom5)
+        GetSources(blossom5int32)
         @build_steps begin
             ChangeDirectory(blossom5srcdir)
-            FileRule(joinpath(libdir(blossom5), "blossom5.so"),
+            FileRule(joinpath(libdir(blossom5int32), "blossom5int32.so"),
                 @build_steps begin
                     CreateDirectory(joinpath(prefix, "lib"))
                     `sh -c "patch < ../../sharedlib.patch"`
                     `sh -c "cp ../../interface/* ./"`
                     MakeTargets(["all"])
-                    `cp blossom5.so $prefix/lib/blossom5.so`
+                    `cp -f blossom5.so $prefix/lib/blossom5int32.so`
                 end)
         end
-    end), blossom5)
+    end), blossom5int32)
 
-@BinDeps.install Dict([(:blossom5, :_jl_blossom5)])
+
+provides(BuildProcess,
+    (@build_steps begin
+        # `rm -rf $prefix`
+        `rm -rf $blossom5srcdir`
+        GetSources(blossom5int32)
+        @build_steps begin
+            ChangeDirectory(blossom5srcdir)
+            FileRule(joinpath(libdir(blossom5int32), "blossom5float64.so"),
+                @build_steps begin
+                    CreateDirectory(joinpath(prefix, "lib"))
+                    `sh -c "patch < ../../sharedlib.patch"`
+                    `sh -c "cp ../../interface/* ./"`
+                    `sh -c "patch < ../../float64.patch"`
+                    MakeTargets(["all"])
+                    `cp -f blossom5.so $prefix/lib/blossom5float64.so`
+                end)
+        end
+    end), blossom5float64)
+
+@BinDeps.install Dict([(:blossom5int32, :_jl_blossom5int32),
+                       (:blossom5float64, :_jl_blossom5float64)])

--- a/deps/float64.patch
+++ b/deps/float64.patch
@@ -1,0 +1,33 @@
+--- PerfectMatching.h	2017-05-30 17:56:13.670015051 +0200
++++ PerfectMatching.new.h	2017-05-30 17:56:58.223569773 +0200
+@@ -37,7 +37,7 @@
+ 
+ 
+ // if defined, edge costs are of type 'double', otherwise 'int'
+-//#define PERFECT_MATCHING_DOUBLE
++#define PERFECT_MATCHING_DOUBLE
+ 
+ // Note: with floating point numbers polynomial complexity is not guaranteed;
+ // the code may even get stuck due to rounding errors. If the code terminates,
+--- interface.h	2017-05-30 17:52:54.969027698 +0200
++++ interface.new.h	2017-05-30 17:58:10.237260946 +0200
+@@ -16,7 +16,7 @@
+ void matching_destruct(matching_t matching);
+ 
+ INTERFACE_EXPORT
+-int32_t matching_add_edge(matching_t matching, int32_t first_node, int32_t second_node, int32_t cost);
++int32_t matching_add_edge(matching_t matching, int32_t first_node, int32_t second_node, double cost);
+ 
+ INTERFACE_EXPORT
+ void matching_solve(matching_t matching);
+--- interface.cpp	2017-05-30 17:52:54.969027698 +0200
++++ interface.new.cpp	2017-05-30 18:00:09.814521797 +0200
+@@ -30,7 +30,7 @@
+     delete matching;
+ }
+ 
+-int32_t matching_add_edge(matching_t matching, int32_t first_node, int32_t second_node, int32_t cost) {
++int32_t matching_add_edge(matching_t matching, int32_t first_node, int32_t second_node, double cost) {
+     matching->actual.AddEdge(first_node, second_node, cost);
+ }
+ 

--- a/src/BlossomV.jl
+++ b/src/BlossomV.jl
@@ -52,7 +52,7 @@ function Matching{T}(::Type{T}, node_num::Integer, edge_num_max::Integer)
         return Matching(T, Int32(node_num), Int32(edge_num_max))
     elseif T <: Integer
         return Matching(Int32, Int32(node_num), Int32(edge_num_max))
-    elseif T <: AbstactFloat
+    else # T <: AbstactFloat
         return Matching(Float64, Int32(node_num), Int32(edge_num_max))
     end
 end

--- a/src/BlossomV.jl
+++ b/src/BlossomV.jl
@@ -11,66 +11,98 @@ export
     PerfectMatchingCtx,
     Matching, solve, add_edge, get_match, get_all_matches
 
-type PerfectMatchingCtx
+
+const CostT = Union{Int32, Float64}
+
+type PerfectMatchingCtx{T<:CostT}
     ptr::Ptr{Void}
 
-    function PerfectMatchingCtx(ptr::Ptr{Void})
-        self = new(ptr)
+     function (::Type{PerfectMatchingCtx{T}}){T<:CostT}(ptr::Ptr{Void})
+        self = new{T}(ptr)
         finalizer(self, destroy)
         verbose(self, false)
         self
     end
 end
 
-function destroy(matching::PerfectMatchingCtx)
+function destroy{T}(matching::PerfectMatchingCtx{T})
     if matching.ptr == C_NULL
         return
     end
-    ccall((:matching_destruct, _jl_blossom5), Void, (Ptr{Void},), matching.ptr)
+    if T == Int32
+        ccall((:matching_destruct, _jl_blossom5int32), Void, (Ptr{Void},), matching.ptr)
+    elseif T == Float64
+        ccall((:matching_destruct, _jl_blossom5float64), Void, (Ptr{Void},), matching.ptr)
+    end
+
     matching.ptr = C_NULL
     nothing
 end
 
-
-
 dense_num_edges(node_num) =  node_num*(node_num-1)÷2
 
-Matching(node_num::Integer) = Matching(node_num, dense_num_edges(node_num))      
-Matching(node_num::Integer, edge_num_max::Integer) = Matching(Int32(node_num), Int32(edge_num_max))
-function Matching(node_num::Int32, edge_num_max::Int32)
+Matching(node_num::Integer) = Matching(Int32, node_num)
+Matching(node_num::Integer, edge_num_max::Integer) = Matching(Int32, node_num, edge_num_max)
+
+Matching{T}(::Type{T}, node_num::Integer) = Matching(T, node_num, dense_num_edges(node_num))
+
+#TODO maybe use dispatch here
+function Matching{T}(::Type{T}, node_num::Integer, edge_num_max::Integer)
+    if T <: CostT
+        return Matching(T, Int32(node_num), Int32(edge_num_max))
+    elseif T <: Integer
+        return Matching(Int32, Int32(node_num), Int32(edge_num_max))
+    elseif T <: AbstactFloat
+        return Matching(Float64, Int32(node_num), Int32(edge_num_max))
+    end
+end
+
+function Matching{T<:CostT}(::Type{T}, node_num::Int32, edge_num_max::Int32)
     assert(node_num % 2 == 0)
-    ptr = ccall((:matching_construct, _jl_blossom5), Ptr{Void}, (Int32, Int32), node_num, edge_num_max)
-    PerfectMatchingCtx(ptr)
+    if T == Int32
+        ptr = ccall((:matching_construct, _jl_blossom5int32), Ptr{Void}, (Int32, Int32), node_num, edge_num_max)
+    elseif T == Float64
+        ptr = ccall((:matching_construct, _jl_blossom5float64), Ptr{Void}, (Int32, Int32), node_num, edge_num_max)
+    end
+    return PerfectMatchingCtx{T}(ptr)
 end
 
 
-
-function add_edge(matching::PerfectMatchingCtx, first_node::Integer, second_node::Integer, cost::Integer)
-	add_edge(matching, Int32(first_node), Int32(second_node), Int32(cost))
+function add_edge{T}(matching::PerfectMatchingCtx{T}, first_node::Integer, second_node::Integer, cost::Number)
+	add_edge(matching, Int32(first_node), Int32(second_node), T(cost))
 end
 
-function add_edge(matching::PerfectMatchingCtx, first_node::Int32, second_node::Int32, cost::Int32)
-    first_node != second_node || error("Can not have an edge between $(first_node) and itself")
-    first_node >= 0  || error("first_node less than zero (value: $(first_node)). Indexes are zero-based")
-    second_node >= 0  || error("second_node less than zero (value: $(second_node)). Indexes are zero-based")
-    cost >= 0  || error("Cost must be positive. edge between $(first_node) and $(second_node) is $cost")
-
-	ccall((:matching_add_edge, _jl_blossom5), Int32, (Ptr{Void}, Int32, Int32, Int32), matching.ptr, first_node, second_node, cost)
+function add_edge{T<:CostT}(matching::PerfectMatchingCtx{T}, first_node::Int32, second_node::Int32, cost::T)
+    first_node != second_node || error("Can not have an edge between $(first_node) and itself.")
+    first_node >= 0  || error("first_node less than zero (value: $(first_node)). Indexes are zero-based.")
+    second_node >= 0  || error("second_node less than zero (value: $(second_node)). Indexes are zero-based.")
+    cost >= 0  || error("Cost must be positive. Edge between $(first_node) and $(second_node) has cost $cost.")
+    if T == Int32
+       ccall((:matching_add_edge, _jl_blossom5int32), Int32, (Ptr{Void}, Int32, Int32, Int32), matching.ptr, first_node, second_node, cost)
+    elseif T == Float64
+       ccall((:matching_add_edge, _jl_blossom5float64), Int32, (Ptr{Void}, Int32, Int32, Float64), matching.ptr, first_node, second_node, cost)
+    end
 end
 
-function solve(matching::PerfectMatchingCtx)
-    ccall((:matching_solve, _jl_blossom5), Void, (Ptr{Void},), matching.ptr)
+function solve{T}(matching::PerfectMatchingCtx{T})
+    if T == Int32
+        ccall((:matching_solve, _jl_blossom5int32), Void, (Ptr{Void},), matching.ptr)
+    elseif T == Float64
+        ccall((:matching_solve, _jl_blossom5float64), Void, (Ptr{Void},), matching.ptr)
+    end
     nothing
 end
 
-
-
 get_match(matching::PerfectMatchingCtx, node::Integer) = get_match(matching, Int32(node))
-function get_match(matching::PerfectMatchingCtx, node::Int32)
-    ccall((:matching_get_match, _jl_blossom5), Int32, (Ptr{Void}, Int32), matching.ptr, node)
+function get_match{T<:CostT}(matching::PerfectMatchingCtx{T}, node::Int32)
+    if T == Int32
+        ccall((:matching_get_match, _jl_blossom5int32), Int32, (Ptr{Void}, Int32), matching.ptr, node)
+    elseif T == Float64
+        ccall((:matching_get_match, _jl_blossom5float64), Int32, (Ptr{Void}, Int32), matching.ptr, node)
+    end
 end
 
-function get_all_matches(m::PerfectMatchingCtx, n_nodes::Integer) 
+function get_all_matches(m::PerfectMatchingCtx, n_nodes::Integer)
     ret = Matrix{Int32}(2, n_nodes÷2)
     assigned = falses(n_nodes)
     kk = 1
@@ -80,7 +112,7 @@ function get_all_matches(m::PerfectMatchingCtx, n_nodes::Integer)
         @assert(!assigned[jj+1])
         assigned[ii+1] = true
         assigned[jj+1] = true
-        
+
         ret[1,kk] = ii
         ret[2,kk] = jj
         kk+=1
@@ -89,8 +121,12 @@ function get_all_matches(m::PerfectMatchingCtx, n_nodes::Integer)
     return ret
 end
 
-function verbose(matching::PerfectMatchingCtx, verbose::Bool)
-    ccall((:matching_verbose, _jl_blossom5), Void, (Ptr{Void}, Bool), matching.ptr, verbose)
+function verbose{T}(matching::PerfectMatchingCtx{T}, verbose::Bool)
+    if T == Int32
+        ccall((:matching_verbose, _jl_blossom5int32), Void, (Ptr{Void}, Bool), matching.ptr, verbose)
+    elseif T == Float64
+        ccall((:matching_verbose, _jl_blossom5float64), Void, (Ptr{Void}, Bool), matching.ptr, verbose)
+    end
 end
 
 end # module

--- a/src/BlossomV.jl
+++ b/src/BlossomV.jl
@@ -14,6 +14,10 @@ export
 
 const CostT = Union{Int32, Float64}
 
+"Returns the blossom library filename for given type"
+blossom_lib(::Type{Float64}) = _jl_blossom5float64
+blossom_lib(::Type{Int32}) = _jl_blossom5int32
+
 type PerfectMatchingCtx{T<:CostT}
     ptr::Ptr{Void}
 
@@ -29,12 +33,7 @@ function destroy{T}(matching::PerfectMatchingCtx{T})
     if matching.ptr == C_NULL
         return
     end
-    if T == Int32
-        ccall((:matching_destruct, _jl_blossom5int32), Void, (Ptr{Void},), matching.ptr)
-    elseif T == Float64
-        ccall((:matching_destruct, _jl_blossom5float64), Void, (Ptr{Void},), matching.ptr)
-    end
-
+    ccall((:matching_destruct, blossom_lib(T)), Void, (Ptr{Void},), matching.ptr)
     matching.ptr = C_NULL
     nothing
 end
@@ -45,28 +44,17 @@ Matching(node_num::Integer) = Matching(Int32, node_num)
 Matching(node_num::Integer, edge_num_max::Integer) = Matching(Int32, node_num, edge_num_max)
 
 Matching{T}(::Type{T}, node_num::Integer) = Matching(T, node_num, dense_num_edges(node_num))
+Matching{T}(::Type{T}, node_num::Integer, edge_num_max::Integer) = Matching(T, Int32(node_num), Int32(edge_num_max))
 
-#TODO maybe use dispatch here
-function Matching{T}(::Type{T}, node_num::Integer, edge_num_max::Integer)
-    if T <: CostT
-        return Matching(T, Int32(node_num), Int32(edge_num_max))
-    elseif T <: Integer
-        return Matching(Int32, Int32(node_num), Int32(edge_num_max))
-    else # T <: AbstactFloat
-        return Matching(Float64, Int32(node_num), Int32(edge_num_max))
-    end
+function Matching{T}(::Type{T}, node_num::Int32, edge_num_max::Int32)
+    error("Only cost types T ∈ $CostT are supported.")
 end
 
 function Matching{T<:CostT}(::Type{T}, node_num::Int32, edge_num_max::Int32)
     assert(node_num % 2 == 0)
-    if T == Int32
-        ptr = ccall((:matching_construct, _jl_blossom5int32), Ptr{Void}, (Int32, Int32), node_num, edge_num_max)
-    elseif T == Float64
-        ptr = ccall((:matching_construct, _jl_blossom5float64), Ptr{Void}, (Int32, Int32), node_num, edge_num_max)
-    end
+    ptr = ccall((:matching_construct, blossom_lib(T)), Ptr{Void}, (Int32, Int32), node_num, edge_num_max)
     return PerfectMatchingCtx{T}(ptr)
 end
-
 
 function add_edge{T}(matching::PerfectMatchingCtx{T}, first_node::Integer, second_node::Integer, cost::Number)
 	add_edge(matching, Int32(first_node), Int32(second_node), T(cost))
@@ -77,29 +65,17 @@ function add_edge{T<:CostT}(matching::PerfectMatchingCtx{T}, first_node::Int32, 
     first_node >= 0  || error("first_node less than zero (value: $(first_node)). Indexes are zero-based.")
     second_node >= 0  || error("second_node less than zero (value: $(second_node)). Indexes are zero-based.")
     cost >= 0  || error("Cost must be positive. Edge between $(first_node) and $(second_node) has cost $cost.")
-    if T == Int32
-       ccall((:matching_add_edge, _jl_blossom5int32), Int32, (Ptr{Void}, Int32, Int32, Int32), matching.ptr, first_node, second_node, cost)
-    elseif T == Float64
-       ccall((:matching_add_edge, _jl_blossom5float64), Int32, (Ptr{Void}, Int32, Int32, Float64), matching.ptr, first_node, second_node, cost)
-    end
+    ccall((:matching_add_edge, blossom_lib(T)), Int32, (Ptr{Void}, Int32, Int32, T), matching.ptr, first_node, second_node, cost)
 end
 
 function solve{T}(matching::PerfectMatchingCtx{T})
-    if T == Int32
-        ccall((:matching_solve, _jl_blossom5int32), Void, (Ptr{Void},), matching.ptr)
-    elseif T == Float64
-        ccall((:matching_solve, _jl_blossom5float64), Void, (Ptr{Void},), matching.ptr)
-    end
+    ccall((:matching_solve, blossom_lib(T)), Void, (Ptr{Void},), matching.ptr)
     nothing
 end
 
 get_match(matching::PerfectMatchingCtx, node::Integer) = get_match(matching, Int32(node))
 function get_match{T<:CostT}(matching::PerfectMatchingCtx{T}, node::Int32)
-    if T == Int32
-        ccall((:matching_get_match, _jl_blossom5int32), Int32, (Ptr{Void}, Int32), matching.ptr, node)
-    elseif T == Float64
-        ccall((:matching_get_match, _jl_blossom5float64), Int32, (Ptr{Void}, Int32), matching.ptr, node)
-    end
+    ccall((:matching_get_match, blossom_lib(T)), Int32, (Ptr{Void}, Int32), matching.ptr, node)
 end
 
 function get_all_matches(m::PerfectMatchingCtx, n_nodes::Integer)
@@ -122,11 +98,7 @@ function get_all_matches(m::PerfectMatchingCtx, n_nodes::Integer)
 end
 
 function verbose{T}(matching::PerfectMatchingCtx{T}, verbose::Bool)
-    if T == Int32
-        ccall((:matching_verbose, _jl_blossom5int32), Void, (Ptr{Void}, Bool), matching.ptr, verbose)
-    elseif T == Float64
-        ccall((:matching_verbose, _jl_blossom5float64), Void, (Ptr{Void}, Bool), matching.ptr, verbose)
-    end
+    ccall((:matching_verbose, blossom_lib(T)), Void, (Ptr{Void}, Bool), matching.ptr, verbose)
 end
 
 end # module

--- a/src/BlossomV.jl
+++ b/src/BlossomV.jl
@@ -8,41 +8,20 @@ else
 end
 
 export
-    Matching,
-    solve, add_edge, get_match, get_all_matches
+    PerfectMatchingCtx,
+    Matching, solve, add_edge, get_match, get_all_matches
 
+
+const CostT = Union{Int32, Float64}
 
 "Returns the blossom library filename for given type"
 blossom_lib(::Type{Float64}) = _jl_blossom5float64
 blossom_lib(::Type{Int32}) = _jl_blossom5int32
 
-
-const CostT = Union{Int32, Float64}
-"""
-    type Matching{T<:Union{Int32, Float64}}
-        ptr::Ptr{Void}
-    end
-
-A type containing a pointer to a BlossomV struct for perfect matching.
-`T` is the type of the edge weights.
-
-The following constructors are available:
-
-    Matching(node_num)
-    Matching(node_num, edge_num_max)
-    Matching(T, node_num)
-    Matching(T, node_num, edge_num_max)
-
-If `T` is not given it will default to `Int32`.
-
-After adding edges and weights with `add_edge(match, i, j, weight)`
-use `solve(match)` to find an optimal matching and `get_match(match, i)`
-to retrieve it.
-"""
-type Matching{T<:CostT}
+type PerfectMatchingCtx{T<:CostT}
     ptr::Ptr{Void}
 
-     function (::Type{Matching{T}}){T<:CostT}(ptr::Ptr{Void})
+     function (::Type{PerfectMatchingCtx{T}}){T<:CostT}(ptr::Ptr{Void})
         self = new{T}(ptr)
         finalizer(self, destroy)
         verbose(self, false)
@@ -50,7 +29,7 @@ type Matching{T<:CostT}
     end
 end
 
-function destroy{T}(matching::Matching{T})
+function destroy{T}(matching::PerfectMatchingCtx{T})
     if matching.ptr == C_NULL
         return
     end
@@ -74,14 +53,14 @@ end
 function Matching{T<:CostT}(::Type{T}, node_num::Int32, edge_num_max::Int32)
     assert(node_num % 2 == 0)
     ptr = ccall((:matching_construct, blossom_lib(T)), Ptr{Void}, (Int32, Int32), node_num, edge_num_max)
-    return Matching{T}(ptr)
+    return PerfectMatchingCtx{T}(ptr)
 end
 
-function add_edge{T}(matching::Matching{T}, first_node::Integer, second_node::Integer, cost::Number)
+function add_edge{T}(matching::PerfectMatchingCtx{T}, first_node::Integer, second_node::Integer, cost::Number)
 	add_edge(matching, Int32(first_node), Int32(second_node), T(cost))
 end
 
-function add_edge{T<:CostT}(matching::Matching{T}, first_node::Int32, second_node::Int32, cost::T)
+function add_edge{T<:CostT}(matching::PerfectMatchingCtx{T}, first_node::Int32, second_node::Int32, cost::T)
     first_node != second_node || error("Can not have an edge between $(first_node) and itself.")
     first_node >= 0  || error("first_node less than zero (value: $(first_node)). Indexes are zero-based.")
     second_node >= 0  || error("second_node less than zero (value: $(second_node)). Indexes are zero-based.")
@@ -89,17 +68,17 @@ function add_edge{T<:CostT}(matching::Matching{T}, first_node::Int32, second_nod
     ccall((:matching_add_edge, blossom_lib(T)), Int32, (Ptr{Void}, Int32, Int32, T), matching.ptr, first_node, second_node, cost)
 end
 
-function solve{T}(matching::Matching{T})
+function solve{T}(matching::PerfectMatchingCtx{T})
     ccall((:matching_solve, blossom_lib(T)), Void, (Ptr{Void},), matching.ptr)
     nothing
 end
 
-get_match(matching::Matching, node::Integer) = get_match(matching, Int32(node))
-function get_match{T<:CostT}(matching::Matching{T}, node::Int32)
+get_match(matching::PerfectMatchingCtx, node::Integer) = get_match(matching, Int32(node))
+function get_match{T<:CostT}(matching::PerfectMatchingCtx{T}, node::Int32)
     ccall((:matching_get_match, blossom_lib(T)), Int32, (Ptr{Void}, Int32), matching.ptr, node)
 end
 
-function get_all_matches(m::Matching, n_nodes::Integer)
+function get_all_matches(m::PerfectMatchingCtx, n_nodes::Integer)
     ret = Matrix{Int32}(2, n_nodes÷2)
     assigned = falses(n_nodes)
     kk = 1
@@ -118,7 +97,7 @@ function get_all_matches(m::Matching, n_nodes::Integer)
     return ret
 end
 
-function verbose{T}(matching::Matching{T}, verbose::Bool)
+function verbose{T}(matching::PerfectMatchingCtx{T}, verbose::Bool)
     ccall((:matching_verbose, blossom_lib(T)), Void, (Ptr{Void}, Bool), matching.ptr, verbose)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
         1 3 1000
     ]
 
-    m = Matching(Int, 4)
+    m = Matching(Int32, 4)
     for row_ii in 1:size(differences,1)
         n1,n2, c = differences[row_ii,:]
         add_edge(m,n1,n2,c)
@@ -67,7 +67,7 @@ end
         1 3 1000
     ]
 
-    m = Matching(Int, 4)
+    m = Matching(Int32, 4)
     for row_ii in 1:size(differences,1)
         n1,n2, c = differences[row_ii,:]
         add_edge(m,Int(n1),Int(n2),c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,24 @@ end
         0 1 500
     ]
 
-    m = Matching(2)
+    m = Matching(2) # defaults to Int32
     for row_ii in 1:size(differences,1)
         n1,n2, c = differences[row_ii,:]
         add_edge(m,n1,n2,c)
+    end
+    solve(m)
+    @test get_match(m,0) == 1
+    @test get_match(m,1) == 0
+
+
+    differences = [
+        0 1 1.3
+    ]
+
+    m = Matching(Float64, 2)
+    for row_ii in 1:size(differences,1)
+        n1,n2, c = differences[row_ii,:]
+        add_edge(m,Int(n1),Int(n2),c)
     end
     solve(m)
     @test get_match(m,0) == 1
@@ -32,7 +46,7 @@ end
         1 3 1000
     ]
 
-    m = Matching(4)
+    m = Matching(Int, 4)
     for row_ii in 1:size(differences,1)
         n1,n2, c = differences[row_ii,:]
         add_edge(m,n1,n2,c)
@@ -44,7 +58,7 @@ end
     @test get_match(m,3) == 2
 end
 
-@testset "Intermidiate Case -- no greedy solution" begin
+@testset "Intermediate Case -- no greedy solution" begin
     differences = [
         0 1 500
         0 2 400
@@ -53,10 +67,10 @@ end
         1 3 1000
     ]
 
-    m = Matching(4)
+    m = Matching(Int, 4)
     for row_ii in 1:size(differences,1)
         n1,n2, c = differences[row_ii,:]
-        add_edge(m,n1,n2,c)
+        add_edge(m,Int(n1),Int(n2),c)
     end
     solve(m)
     @test get_match(m,0) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
         1 3 1000
     ]
 
-    m = Matching(Int32, 4)
+    m = Matching(Int, 4)
     for row_ii in 1:size(differences,1)
         n1,n2, c = differences[row_ii,:]
         add_edge(m,n1,n2,c)
@@ -67,7 +67,7 @@ end
         1 3 1000
     ]
 
-    m = Matching(Int32, 4)
+    m = Matching(Int, 4)
     for row_ii in 1:size(differences,1)
         n1,n2, c = differences[row_ii,:]
         add_edge(m,Int(n1),Int(n2),c)


### PR DESCRIPTION
Hi @mlewe,
I found myself in need of a matching algorithm for non-integer weights. I implemented in Erdos and LightGraphs a crappy conversion from floats to integers through linear transform and rounding, but sometimes it yields the wrong results. 

BlossomV supports real weights, although it cautions against possible precision errors. It would be possible for BlossomV.jl to compile and support both the integer and the floating versions of BlossomV? A possible solution would be to parametrize with Matching{T}, and dispatch on the base of T to the appropriate ccall

For the time being I just switched entirely to the floating point version of the code, to check if it works

